### PR TITLE
fix: Fix dimmed background in bottom sheet dialogs

### DIFF
--- a/jc-edge-to-edge/src/main/java/dev/katiebarnett/experiments/jcedgetoedge/MainActivity.kt
+++ b/jc-edge-to-edge/src/main/java/dev/katiebarnett/experiments/jcedgetoedge/MainActivity.kt
@@ -135,6 +135,8 @@ class MainActivity : ComponentActivity() {
                                 val attributes = WindowManager.LayoutParams()
                                 attributes.copyFrom(activityWindow.attributes)
                                 attributes.type = dialogWindow.attributes.type
+                                attributes.dimAmount = dialogWindow.attributes.dimAmount
+                                attributes.flags = dialogWindow.attributes.flags
                                 dialogWindow.attributes = attributes
                                 parentView.layoutParams = LayoutParams(
                                     activityWindow.decorView.width,


### PR DESCRIPTION
When I used this solution with bottom sheets, it works fine, the only issue that I had was the loss of the dimmed background.

The reason is when copy the attributes from the `Activity window` to the `Dialog window`, we lose the `dimAmount` and the `flags`

This will fix the issue and brings back the dimmed background

@KatieBarnett 